### PR TITLE
refactor: use logger to replace arranger

### DIFF
--- a/src/recnys/logger.py
+++ b/src/recnys/logger.py
@@ -3,19 +3,35 @@ from pathlib import Path
 from typing import TYPE_CHECKING, override
 
 if TYPE_CHECKING:
-    import argparse
     from logging import _SysExcInfoType
 
-__all__ = ["arrange"]
+__all__ = ["setup_logger"]
 
 
-def arrange(args: argparse.Namespace) -> None:
-    """Do the necessary arrangements before executing the main logic.
+def setup_logger(*, silent: bool, debug: bool) -> None:
+    """Configure the handlers and logging level for the top-level logger.
+
+    The logger by default only has a console handler, and has INFO logging level.
 
     Args:
-        args: The parsed command-line arguments.
+        silent (bool): If True, the logging level is set to WARNING.
+        debug (bool): If True, the logging level is set to DEBUG (overrides `silent`).
+            An additional file handler will also be added.
     """
-    _setup_logger(Path.cwd() / "recnys.log", silent=args.silent, debug=args.debug)
+    logger = logging.getLogger("recnys")
+    logger.handlers.clear()
+
+    console_handler = _get_console_handler()
+    logger.addHandler(console_handler)
+
+    if not silent and not debug:
+        logger.setLevel(logging.INFO)
+    elif silent and not debug:
+        logger.setLevel(logging.WARNING)
+    else:
+        logger.setLevel(logging.DEBUG)
+        file_handler = _get_file_handler(Path.cwd() / "recnys.log")
+        logger.addHandler(file_handler)
 
 
 class _NoTrackBackFormatter(logging.Formatter):
@@ -45,30 +61,3 @@ def _get_file_handler(log_file: Path) -> logging.FileHandler:
     handler.setFormatter(formatter)
 
     return handler
-
-
-def _setup_logger(log_file: Path, *, silent: bool, debug: bool) -> None:
-    """Configure the top-level logger for recnys.
-
-    Logging level:
-
-    - If debug is True, set to DEBUG (overrides silent)
-    - If silent is True, set to WARNING
-    - Otherwise, set to INFO
-    """
-    logger = logging.getLogger("recnys")
-
-    logger.handlers.clear()
-
-    console_handler = _get_console_handler()
-    logger.addHandler(console_handler)
-
-    if silent:
-        logger.setLevel(logging.WARNING)
-    else:
-        logger.setLevel(logging.INFO)
-
-    if debug:
-        file_handler = _get_file_handler(log_file)
-        logger.addHandler(file_handler)
-        logger.setLevel(logging.DEBUG)

--- a/src/recnys/main.py
+++ b/src/recnys/main.py
@@ -2,8 +2,8 @@ import argparse
 
 from recnys import __version__
 
-from .arranger import arrange
 from .handler import handle_exceptions
+from .logger import setup_logger
 from .pipeline import BackendPipeline, FrontendPipeline
 
 
@@ -39,13 +39,12 @@ def parse_arguments() -> argparse.Namespace:
 @handle_exceptions
 def main(argv: argparse.Namespace | None = None) -> int:
     args = parse_arguments() if argv is None else argv
+    setup_logger(silent=args.silent, debug=args.debug)
 
-    arrange(args)
+    frontend = FrontendPipeline()
+    scanned_config = frontend.run()
 
-    pipeline = FrontendPipeline()
-    scanned_config = pipeline.run()
-
-    pipeline = BackendPipeline()
-    pipeline.run(scanned_config, dry_run=args.dry_run)
+    backend = BackendPipeline()
+    backend.run(scanned_config, dry_run=args.dry_run)
 
     return 0


### PR DESCRIPTION
In order to avoid naming ambiguity. 'arranger' is reserved for 'arrangement' in test.
